### PR TITLE
Update ConvertPolicyXmlToBinary.ps1 (.cip instead of .bin)

### DIFF
--- a/Windows Defender/Scripts/WDAC/Convert Policy/ConvertPolicyXmlToBinary.ps1
+++ b/Windows Defender/Scripts/WDAC/Convert Policy/ConvertPolicyXmlToBinary.ps1
@@ -50,7 +50,7 @@ param
 if (-not $BinaryFile)
 {
     [xml] $XmlPolicy = Get-Content $XmlPolicyFile
-    $BinaryFile = "{0}.bin" -f $XmlPolicy.SiPolicy.PolicyID
+    $BinaryFile = "{0}.cip" -f $XmlPolicy.SiPolicy.PolicyID
 }
 
 ConvertFrom-CIPolicy -XmlFilePath $XmlPolicyFile -BinaryFilePath $BinaryFile 


### PR DESCRIPTION
Hi,
Thanks for the useful script!
I've been scratching my head about the .bin ending, though. It is my understanding that only .cip is detected as a valid policy file.
Since .cip is referenced everywhere, and the policy works normally when changing the ending manually to .cip, I propose making the file extension .cip the default. 
Unless there is a reason for using .bin that is eluding me currently.
Best regards
Fabio